### PR TITLE
update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   ],
   "dependencies": {
     "duplexer2": "^0.0.2",
-    "merge-stream": "^0.1.0",
+    "merge-stream": "^0.1.5",
     "fork-stream": "^0.0.4",
-    "through2": "^0.5.1"
+    "through2": "^0.6.1"
   },
   "devDependencies": {
     "jshint": "^2.5.0",


### PR DESCRIPTION
merge-stream 0.1.0 was unpublished or something, because gulp-if (due to ternary-stream) was failing to install with this error

```
~/Projects/spark (master*) ❯ npm install gulp-if
npm ERR! Error: version not found: merge-stream@0.1.0
npm ERR!     at setData (/usr/local/lib/node_modules/npm/lib/cache/add-named.js:127:12)
npm ERR!     at saved (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:167:7)
npm ERR!     at /usr/local/lib/node_modules/npm/node_modules/cmd-shim/node_modules/graceful-fs/polyfills.js:133:7
npm ERR!     at Object.oncomplete (fs.js:107:15)
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! System Darwin 14.0.0
npm ERR! command "node" "/usr/local/bin/npm" "install" "gulp-if"
npm ERR! cwd /Users/contra/Projects/spark
npm ERR! node -v v0.10.31
npm ERR! npm -v 2.0.0-beta.0
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/contra/Projects/spark/npm-debug.log
npm ERR! not ok code 0
```

Strange. Anyways I updated the merge-stream dependency to solve this problem. Could you publish this ASAP as a patch? I'm sure plenty of people are having trouble with this.
