### PR TITLE
replace invalid `licenses` with valid `license`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,5 @@
   "engines": {
     "node": ">= 0.10.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/robrich/ternary-stream/raw/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
`type` and `url` are now depreciated.

http://npm1k.org/
https://docs.npmjs.com/files/package.json#license
